### PR TITLE
Add DexPaprika and CoinPaprika to Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Contributions are most welcome. Categories are also open to suggestions!
 - [Cookie3](https://www.cookie3.co/): Your gateway to MarketingFi.
 - [Dune](https://dune.com/): Query, visualize, share and export data across 15+ blockchains.
 - [Nansen](https://www.nansen.ai/): Onchain Analytics Platform designed for investors.
-- [DexPaprika](https://api.dexpaprika.com): Free DEX data API across 34 blockchains. 30M+ pools, 27M+ tokens, real-time SSE streaming. No API key.
-- [CoinPaprika](https://api.coinpaprika.com): Free crypto market data for 12K+ coins, 350+ exchanges, tickers, OHLCV. No API key for free tier.
+- [DexPaprika](https://api.dexpaprika.com): DEX data API across 36 blockchains. Free tier, no API key required.
+- [CoinPaprika](https://api.coinpaprika.com): Crypto market data for 12,000+ coins and 350+ exchanges. Free tier, no API key required.
 
 ## Payroll 💰
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Contributions are most welcome. Categories are also open to suggestions!
 - [Cookie3](https://www.cookie3.co/): Your gateway to MarketingFi.
 - [Dune](https://dune.com/): Query, visualize, share and export data across 15+ blockchains.
 - [Nansen](https://www.nansen.ai/): Onchain Analytics Platform designed for investors.
+- [DexPaprika](https://api.dexpaprika.com): Free DEX data API across 34 blockchains. 30M+ pools, 27M+ tokens, real-time SSE streaming. No API key.
+- [CoinPaprika](https://api.coinpaprika.com): Free crypto market data for 12K+ coins, 350+ exchanges, tickers, OHLCV. No API key for free tier.
 
 ## Payroll 💰
 


### PR DESCRIPTION
Adds two crypto data APIs to the Analytics section, next to Dune and Nansen:

- DexPaprika: DEX data API across 36 chains. Pools, tokens, OHLCV, trades.
- CoinPaprika: market data for 12,000+ coins and 350+ exchanges. Tickers, OHLCV, historical prices.

Both have a free tier that works without an API key, so the links go straight to the API roots. Both free tiers are metered, current limits are on https://dexpaprika.com/api/pricing and https://coinpaprika.com/api/.
